### PR TITLE
Update the URL to SOFA feed

### DIFF
--- a/super
+++ b/super
@@ -288,7 +288,7 @@ set_defaults() {
 	readonly MSU_LIST_LOG
 	
 	# URL to the default SOFA macOS machine readable json feed:
-	SOFA_MACOS_DEFAULT_URL="https://sofa.macadmins.io/v1/macos_data_feed.json"
+	SOFA_MACOS_DEFAULT_URL="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 	readonly SOFA_MACOS_DEFAULT_URL
 	
 	# Path to the local copy of the SOFA machine readable feed:


### PR DESCRIPTION
Hi @Macjutsuquick heads up -  as shared on slack macadmins-opensource the SOFA feed URL should be updated. 

For details also see https://sofa.macadmins.io/use-cases.html#sofa-use-cases:

Please update your scripts that are utilising the SOFA macOS to point to `https://sofafeed.macadmins.io/v1/macos_data_feed.json` 

The old feed addresses of https://sofa.macadmins.io/v1/macos_data_feed.json is deprecated and will be removed soon.