### PR TITLE
Fix for --scheduled-install-days validation

### DIFF
--- a/super
+++ b/super
@@ -1760,7 +1760,7 @@ manage_parameter_options() {
 		set_pref "ScheduledInstallDays" "${scheduled_install_days}"
 	fi
 	[[ -z "${scheduled_install_days}" ]] && scheduled_install_days=$(get_pref "ScheduledInstallDays")
-	{ [[ -n "${scheduled_install_days}" ]] && [[ ! "${scheduled_install_days_option}" =~ ${REGEX_ANY_WHOLE_NUMBER} ]]; } && log_super "Parameter Error: The --scheduled-install-days=number value must only be a number." && parameter_error="TRUE"
+	{ [[ -n "${scheduled_install_days}" ]] && [[ ! "${scheduled_install_days}" =~ ${REGEX_ANY_WHOLE_NUMBER} ]]; } && log_super "Parameter Error: The --scheduled-install-days=number value must only be a number." && parameter_error="TRUE"
 	{ [[ "${verbose_mode}" == "TRUE" ]] && [[ -n "${scheduled_install_days}" ]]; } && log_super "Verbose Mode: Function ${FUNCNAME[0]}: Line ${LINENO}: scheduled_install_days is: ${scheduled_install_days}"
 	
 	# Validate ${scheduled_install_date_option} input and if valid set the ${scheduled_install_date} parameter.


### PR DESCRIPTION
Fixing --scheduled_install_days validation logic
Current version is checking against scheduled_install_days_option which fails if no argument is provided in the command line