### PR TITLE
Update Regex for Major Version to allow macOS 26

### DIFF
--- a/super
+++ b/super
@@ -488,7 +488,7 @@ set_defaults() {
 	readonly TEST_MODE_DEFAULT_TIMEOUT
 	
 	# Various regular expressions used for parameter validation.
-	REGEX_MACOS_MAJOR_VERSION="^([1-2][1-9])$"
+	REGEX_MACOS_MAJOR_VERSION="^([0-9][0-9])$"
 	readonly REGEX_MACOS_MAJOR_VERSION
 	REGEX_ANY_WHOLE_NUMBER="^[0-9]+$"
 	readonly REGEX_ANY_WHOLE_NUMBER


### PR DESCRIPTION
When preparing Profiles for macOS 26 updates i noticed that a target version of 26 would fail.

The old Regex only allows Major Versions starting with 1.
This allows it to start with 1 or 2.
