### PR TITLE
restrictions & deadlines

### DIFF
--- a/super
+++ b/super
@@ -5314,6 +5314,15 @@ check_schedule_zero_date() {
 			if [[ $(sqlite3 /dev/null "SELECT json_extract(readfile('${SOFA_MACOS_JSON_CACHE}'), '$.OSVersions[$sofa_osversions_array_index].SecurityReleases[$array_index].ProductVersion')" 2>/dev/null) == "${schedule_zero_date_version_target}" ]]; then
 				schedule_zero_date=$(sqlite3 /dev/null "SELECT json_extract(readfile('${SOFA_MACOS_JSON_CACHE}'), '$.OSVersions[$sofa_osversions_array_index].SecurityReleases[$array_index].ReleaseDate')" 2>/dev/null | sed -e 's/T/:/g' -e 's/:00Z//g')
 				log_super_audit "Status: Setting new automatic zero date based on the ${workflow_target} release date of ${schedule_zero_date}."
+				local deferral_restrictions_offset_days=0
+				{ [[ "${macos_msu_major_upgrade_target}" != "FALSE" ]] || [[ "${macos_installer_major_upgrade_target}" != "FALSE" ]]; } && [[ "${deferral_restrictions_macOS_major_upgrades}" != "FALSE" ]] && deferral_restrictions_offset_days="${deferral_restrictions_macOS_major_upgrades}"
+				{ [[ "${macos_msu_minor_update_target}" != "FALSE" ]] || [[ "${macos_installer_minor_update_target}" != "FALSE" ]]; } && [[ "${deferral_restrictions_macOS_minor_updates}" != "FALSE" ]] && deferral_restrictions_offset_days="${deferral_restrictions_macOS_minor_updates}"
+				if [[ $deferral_restrictions_offset_days -gt 0 ]]; then
+					local schedule_zero_date_epoch_temp
+					schedule_zero_date_epoch_temp=$(date -j -f %Y-%m-%d:%H:%M:%S "${schedule_zero_date}:00" +%s)
+					schedule_zero_date=$(date -r $((schedule_zero_date_epoch_temp + (deferral_restrictions_offset_days * 86400))) +%Y-%m-%d:%H:%M)
+					log_super "Status: Restrictions configuration profile offset of ${deferral_restrictions_offset_days} days adjusting automatic zero date to ${schedule_zero_date}."
+				fi
 				set_pref_main "ScheduleZeroDateAutomaticRelease" "${schedule_zero_date}"
 				[[ -n "${schedule_zero_date_automatic_start_previous}" ]] && delete_pref_main "ScheduleZeroDateAutomaticStart" && unset schedule_zero_date_automatic_start_previous
 				break
@@ -6583,7 +6592,9 @@ workflow_check_software_status() {
 		[[ "${verbose_mode}" == "TRUE" ]] && log_super "Verbose Mode: Function ${FUNCNAME[0]}: Line ${LINENO}: macos_msu_major_upgrade_target_version_normalized is: ${macos_msu_major_upgrade_target_version_normalized}"
 		
 		# If ${install_macos_major_upgrades} and there is no ${macos_msu_major_upgrade_target} then attempt to resolve a ${macos_installer_major_upgrade_target} given ${install_macos_major_version_target} and ${macos_installer_major_upgrades_array[]}.
-		if [[ "${install_macos_major_upgrades}" == "TRUE" ]] && [[ "${macos_msu_major_upgrade_target}" == "FALSE" ]] && [[ ${#macos_installer_major_upgrades_array[@]} -gt 0 ]]; then
+		# However, if a restrictions configuration profile is deferring macOS major upgrades, also defer installer-based major upgrades to honor the same deferral window.
+		[[ "${install_macos_major_upgrades}" == "TRUE" ]] && [[ "${macos_msu_major_upgrade_target}" == "FALSE" ]] && [[ ${#macos_installer_major_upgrades_array[@]} -gt 0 ]] && [[ "${deferral_restrictions_macOS_major_upgrades}" != "FALSE" ]] && log_super "Disallowed: macOS major upgrade installer is available but not allowed for ${deferral_restrictions_macOS_major_upgrades} days per restrictions configuration profile."
+		if [[ "${install_macos_major_upgrades}" == "TRUE" ]] && [[ "${macos_msu_major_upgrade_target}" == "FALSE" ]] && [[ ${#macos_installer_major_upgrades_array[@]} -gt 0 ]] && [[ "${deferral_restrictions_macOS_major_upgrades}" == "FALSE" ]]; then
 			if [[ -z "${install_macos_major_version_target}" ]]; then
 				macos_installer_major_upgrade_target="${macos_installer_major_upgrades_array[0]}"
 				[[ "${deferral_restrictions_macOS_major_upgrades}" == "FALSE" ]] && macos_major_upgrade_latest="TRUE"
@@ -6640,7 +6651,9 @@ workflow_check_software_status() {
 		[[ "${verbose_mode}" == "TRUE" ]] && log_super "Verbose Mode: Function ${FUNCNAME[0]}: Line ${LINENO}: macos_minor_update_latest is: ${macos_minor_update_latest}"
 		
 		# If ${install_macos_minor_updates} and there is no ${macos_msu_major_upgrade_target} or ${macos_installer_major_upgrade_target} or ${macos_msu_minor_update} then attempt to resolve a ${macos_installer_minor_update_target} given ${install_macos_minor_version_target} and ${macos_installer_minor_updates_array[]}.
-		if [[ "${install_macos_minor_updates}" == "TRUE" ]] && [[ "${macos_msu_major_upgrade_target}" == "FALSE" ]] && [[ "${macos_installer_major_upgrade_target}" == "FALSE" ]] && [[ "${macos_msu_minor_update_target}" == "FALSE" ]] && [[ ${#macos_installer_minor_updates_array[@]} -gt 0 ]]; then
+		# However, if a restrictions configuration profile is deferring macOS minor updates, also defer installer-based minor updates to honor the same deferral window.
+		[[ "${install_macos_minor_updates}" == "TRUE" ]] && [[ "${macos_msu_major_upgrade_target}" == "FALSE" ]] && [[ "${macos_installer_major_upgrade_target}" == "FALSE" ]] && [[ "${macos_msu_minor_update_target}" == "FALSE" ]] && [[ ${#macos_installer_minor_updates_array[@]} -gt 0 ]] && [[ "${deferral_restrictions_macOS_minor_updates}" != "FALSE" ]] && log_super "Disallowed: macOS minor update installer is available but not allowed for ${deferral_restrictions_macOS_minor_updates} days per restrictions configuration profile."
+		if [[ "${install_macos_minor_updates}" == "TRUE" ]] && [[ "${macos_msu_major_upgrade_target}" == "FALSE" ]] && [[ "${macos_installer_major_upgrade_target}" == "FALSE" ]] && [[ "${macos_msu_minor_update_target}" == "FALSE" ]] && [[ ${#macos_installer_minor_updates_array[@]} -gt 0 ]] && [[ "${deferral_restrictions_macOS_minor_updates}" == "FALSE" ]]; then
 			if [[ -z "${install_macos_minor_version_target}" ]]; then
 				macos_installer_minor_update_target="${macos_installer_minor_updates_array[0]}"
 			else

--- a/super
+++ b/super
@@ -7387,20 +7387,14 @@ workflow_download_macos() {
 	if [[ "${macos_installer_download_required}" == "TRUE" ]] || [[ "${macos_msu_download_required}" == "TRUE" ]]; then
 		# If a macOS automatic download should be possible then automatically defer.
 		if [[ "${macos_msu_automatic_download_deferral}" == "TRUE" ]]; then
-			if [[ "${workflow_install_now_active}" != "TRUE" ]] && [[ "${deadline_date_status}" == "FALSE" ]] && [[ "${deadline_days_status}" == "FALSE" ]] && [[ "${deadline_count_status}" == "FALSE" ]]; then
-				# If a deadline is within 24 hours, override the download deferral to pre-download the update so it's ready when the deadline arrives.
-				if [[ -n "${deadline_epoch}" ]] && [[ $((deadline_epoch - workflow_time_epoch)) -le 86400 ]]; then
-					log_super "Warning: Ignoring automatic macOS minor update download deferral because a deadline is within 24 hours, pre-downloading update."
-				else
-					if [[ "${macos_msu_automatic_download_ramped}" != "FALSE" ]]; then
-						log_super "Warning: The target macOS minor update has not yet automatically downloaded to the system because it's being delayed by Apple's incremental rollout mechanism, trying again in ${deferral_timer_minutes} minutes."
-						log_status "Pending: The target macOS minor update has not yet automatically downloaded to the system because it's being delayed by Apple's incremental rollout mechanism, trying again in ${deferral_timer_minutes} minutes."
-					else
-						log_super "Warning: The target macOS minor update has not yet automatically downloaded to the system, trying again in ${deferral_timer_minutes} minutes."
-						log_status "Pending: The target macOS minor update has not yet automatically downloaded to the system, trying again in ${deferral_timer_minutes} minutes."
-					fi
-					set_auto_launch_deferral
-				fi
+			if [[ "${macos_msu_automatic_download_ramped}" != "FALSE" ]]; then
+				# Apple's incremental rollout is blocking the automatic background download. Rather than deferring indefinitely, proceed to download the update directly so it's ready when the user is prompted.
+				log_super "Warning: The target macOS minor update automatic download is being delayed by Apple's incremental rollout mechanism, overriding to download directly."
+			elif [[ "${workflow_install_now_active}" != "TRUE" ]] && [[ "${deadline_date_status}" == "FALSE" ]] && [[ "${deadline_days_status}" == "FALSE" ]] && [[ "${deadline_count_status}" == "FALSE" ]]; then
+				# No deadline has passed and the system should be able to download automatically, defer and let the system handle it.
+				log_super "Warning: The target macOS minor update has not yet automatically downloaded to the system, trying again in ${deferral_timer_minutes} minutes."
+				log_status "Pending: The target macOS minor update has not yet automatically downloaded to the system, trying again in ${deferral_timer_minutes} minutes."
+				set_auto_launch_deferral
 			else
 				[[ "${workflow_install_now_active}" == "TRUE" ]] && log_super "Warning: Ignoring automatic macOS minor update download deferral due to current install now workflow."
 				{ [[ "${deadline_date_status}" != "FALSE" ]] || [[ "${deadline_days_status}" != "FALSE" ]] || [[ "${deadline_count_status}" != "FALSE" ]]; } && log_super "Warning: Ignoring automatic macOS minor update download deferral due to current deadline workflow."

--- a/super
+++ b/super
@@ -5680,7 +5680,7 @@ check_deadlines_days_date() {
 			deadline_date_hard_difference=$((deadline_date_hard_epoch - workflow_time_epoch))
 			[[ "${verbose_mode}" == "TRUE" ]] && log_super "Verbose Mode: Function ${FUNCNAME[0]}: Line ${LINENO}: deadline_date_hard_difference is: ${deadline_date_hard_difference}"
 			if [[ $deadline_date_hard_difference -le 180 ]]; then
-				log_super "Status: Hard deadline date of ${deadline_date_soft} is only ${deadline_date_hard_difference} seconds away, waiting for deadline to pass..."
+				log_super "Status: Hard deadline date of ${deadline_date_hard} is only ${deadline_date_hard_difference} seconds away, waiting for deadline to pass..."
 				sleep $((deadline_date_hard_difference + 1))
 				log_super "Status: Hard deadline date of ${deadline_date_soft} has passed."
 				deadline_date_status="HARD"
@@ -7388,14 +7388,19 @@ workflow_download_macos() {
 		# If a macOS automatic download should be possible then automatically defer.
 		if [[ "${macos_msu_automatic_download_deferral}" == "TRUE" ]]; then
 			if [[ "${workflow_install_now_active}" != "TRUE" ]] && [[ "${deadline_date_status}" == "FALSE" ]] && [[ "${deadline_days_status}" == "FALSE" ]] && [[ "${deadline_count_status}" == "FALSE" ]]; then
-				if [[ "${macos_msu_automatic_download_ramped}" != "FALSE" ]]; then
-					log_super "Warning: The target macOS minor update has not yet automatically downloaded to the system because it's being delayed by Apple's incremental rollout mechanism, trying again in ${deferral_timer_minutes} minutes."
-					log_status "Pending: The target macOS minor update has not yet automatically downloaded to the system because it's being delayed by Apple's incremental rollout mechanism, trying again in ${deferral_timer_minutes} minutes."
+				# If a deadline is within 24 hours, override the download deferral to pre-download the update so it's ready when the deadline arrives.
+				if [[ -n "${deadline_epoch}" ]] && [[ $((deadline_epoch - workflow_time_epoch)) -le 86400 ]]; then
+					log_super "Warning: Ignoring automatic macOS minor update download deferral because a deadline is within 24 hours, pre-downloading update."
 				else
-					log_super "Warning: The target macOS minor update has not yet automatically downloaded to the system, trying again in ${deferral_timer_minutes} minutes."
-					log_status "Pending: The target macOS minor update has not yet automatically downloaded to the system, trying again in ${deferral_timer_minutes} minutes."
+					if [[ "${macos_msu_automatic_download_ramped}" != "FALSE" ]]; then
+						log_super "Warning: The target macOS minor update has not yet automatically downloaded to the system because it's being delayed by Apple's incremental rollout mechanism, trying again in ${deferral_timer_minutes} minutes."
+						log_status "Pending: The target macOS minor update has not yet automatically downloaded to the system because it's being delayed by Apple's incremental rollout mechanism, trying again in ${deferral_timer_minutes} minutes."
+					else
+						log_super "Warning: The target macOS minor update has not yet automatically downloaded to the system, trying again in ${deferral_timer_minutes} minutes."
+						log_status "Pending: The target macOS minor update has not yet automatically downloaded to the system, trying again in ${deferral_timer_minutes} minutes."
+					fi
+					set_auto_launch_deferral
 				fi
-				set_auto_launch_deferral
 			else
 				[[ "${workflow_install_now_active}" == "TRUE" ]] && log_super "Warning: Ignoring automatic macOS minor update download deferral due to current install now workflow."
 				{ [[ "${deadline_date_status}" != "FALSE" ]] || [[ "${deadline_days_status}" != "FALSE" ]] || [[ "${deadline_count_status}" != "FALSE" ]]; } && log_super "Warning: Ignoring automatic macOS minor update download deferral due to current deadline workflow."
@@ -9785,7 +9790,7 @@ open_dialog_ibm_notifier() {
 					ibm_notifier_array+=(-secondary_accessory_view_type secureinput -secondary_accessory_view_payload "${display_accessory_secure_payload}" -timeout "${dialog_timeout_seconds}")
 				fi
 			else # Remaining ${dialog_type}s; REMINDER, SOFT.
-				[[ -n "${dialog_timeout_seconds}" ]] && ibm_notifier_array+=(-secondary_accessory_view_type timer -accessory_view_payload "${display_string_dialog_timeout} %@" -timeout "${dialog_timeout_seconds}")
+				[[ -n "${dialog_timeout_seconds}" ]] && ibm_notifier_array+=(-secondary_accessory_view_type timer -secondary_accessory_view_payload "${display_string_dialog_timeout} %@" -timeout "${dialog_timeout_seconds}")
 			fi
 		else # No custom display accessory.
 			if [[ "${dialog_type}" == "CHOICE" ]]; then


### PR DESCRIPTION
If a restriction profile is applied, super should honor that regardless

Once a restriction profile expires, the zero date should be set to then and the deadlines should stack with the restrictions